### PR TITLE
Update for Thunderbird 54

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,5 +1,5 @@
 overlay	chrome://messenger/content/messengercompose/messengercompose.xul	chrome://extedit/content/extedit.xul
 overlay	chrome://global/content/customizeToolbar.xul	chrome://extedit/content/extedit.xul
-content	extedit	/chrome/content/
-locale	extedit	en-US	/chrome/locale/en-US/extedit/
+content	extedit	chrome/content/
+locale	extedit	en-US	chrome/locale/en-US/extedit/
 

--- a/chrome/content/extedit.js
+++ b/chrome/content/extedit.js
@@ -292,17 +292,17 @@ function initExtedit() {
 
 	settingsObserver = new extEditSettingsObserver();
 
-	var editHtmlAsHtml = nsPreferences.getBoolPref('extedit.html.editAsHtml', true);
-	prefNotifierExe                      = nsPreferences.copyUnicharPref('extedit.default.editor', "");
-	prefEditorUnicode                    = nsPreferences.getBoolPref('extedit.editor.unicode', true);
-	prefEditor83Filename                 = nsPreferences.getBoolPref('extedit.editor.83filename', false);
-	prefEditHeaders[extedit_GLOBAL]    = nsPreferences.getBoolPref('extedit.headers.edit', true);
-	prefEditHeaders[extedit_SUBJECT]   = nsPreferences.getBoolPref('extedit.headers.edit.subject', true);
-	prefEditHeaders[extedit_TO]        = nsPreferences.getBoolPref('extedit.headers.edit.to', true);
-	prefEditHeaders[extedit_CC]        = nsPreferences.getBoolPref('extedit.headers.edit.cc', true);
-	prefEditHeaders[extedit_BCC]       = nsPreferences.getBoolPref('extedit.headers.edit.bcc', true); 
-	prefEditHeaders[extedit_REPLY_TO]  = nsPreferences.getBoolPref('extedit.headers.edit.replyto', false);
-	prefEditHeaders[extedit_NEWSGROUP] = nsPreferences.getBoolPref('extedit.headers.edit.newsgroup', false);
+	var editHtmlAsHtml                 = customPrefs.getBoolPref('extedit.html.editAsHtml', true);
+	prefNotifierExe                    = customPrefs.copyUnicharPref('extedit.default.editor', "");
+	prefEditorUnicode                  = customPrefs.getBoolPref('extedit.editor.unicode', true);
+	prefEditor83Filename               = customPrefs.getBoolPref('extedit.editor.83filename', false);
+	prefEditHeaders[extedit_GLOBAL]    = customPrefs.getBoolPref('extedit.headers.edit', true);
+	prefEditHeaders[extedit_SUBJECT]   = customPrefs.getBoolPref('extedit.headers.edit.subject', true);
+	prefEditHeaders[extedit_TO]        = customPrefs.getBoolPref('extedit.headers.edit.to', true);
+	prefEditHeaders[extedit_CC]        = customPrefs.getBoolPref('extedit.headers.edit.cc', true);
+	prefEditHeaders[extedit_BCC]       = customPrefs.getBoolPref('extedit.headers.edit.bcc', true); 
+	prefEditHeaders[extedit_REPLY_TO]  = customPrefs.getBoolPref('extedit.headers.edit.replyto', false);
+	prefEditHeaders[extedit_NEWSGROUP] = customPrefs.getBoolPref('extedit.headers.edit.newsgroup', false);
 
 	initButton(prefNotifierExe, editHtmlAsHtml);
 	headersEnd = "-=-=-=-=-=-=-=-=-=# " + getLocaleString("DontRemoveThisLine") + " #=-=-=-=-=-=-=-=-=-" + newLine;
@@ -310,7 +310,7 @@ function initExtedit() {
 
 //-----------------------------------------------------------------------------
 function savePrefEditHtmlAsHtml(flag) {
-	nsPreferences.setBoolPref('extedit.html.editAsHtml', flag);
+	customPrefs.setBoolPref('extedit.html.editAsHtml', flag);
 }
 
 //-----------------------------------------------------------------------------

--- a/chrome/content/pref.js
+++ b/chrome/content/pref.js
@@ -1,4 +1,66 @@
-// This needs: chrome://global/content/nsUserSettings.js
+/*
+ * customPrefs wrapper sourced from:
+ *   http://qiita.com/sayamada/items/d6d26a3c2e9613854019
+ * Thanks sayamada!
+ */
+var customPrefs = {
+
+	orgPrefs: Components.classes["@mozilla.org/preferences-service;1"]
+		.getService(Components.interfaces.nsIPrefService)
+		.getBranch(""),
+
+	copyUnicharPref: function(key, defaultVal) {
+		if (defaultVal === undefined) {
+			defaultVal = "";
+		}
+		var val = undefined;
+		try {
+			val = this.orgPrefs.getComplexValue(key, Components.interfaces.nsISupportsString).data;
+		} catch (e) {
+			console.log(e);
+		}
+		if (val !== undefined && val !== "") {
+			return val;
+		} else {
+			return defaultVal;
+		}
+	},
+	setUnicharPref: function(key, val) {
+		var str = Components.classes["@mozilla.org/supports-string;1"]
+			.createInstance(Components.interfaces.nsISupportsString);
+		str.data = val;
+		this.orgPrefs.setComplexValue(key, Components.interfaces.nsISupportsString, str);
+	},
+	getBoolPref: function(key, defaultVal) {
+		try {
+			var tmpVal = this.orgPrefs.getBoolPref(key);
+			if (tmpVal || tmpVal === "true") {
+				return true;
+			} else {
+				return false;
+			}
+		} catch (e) {
+			return defaultVal;
+		}
+	},
+	setBoolPref: function(key, val) {
+		if (val || val === "true") {
+			this.orgPrefs.setBoolPref(key, true);
+		} else {
+			this.orgPrefs.setBoolPref(key, false);
+		}
+	},
+	getIntPref: function(key, defaultVal) {
+		try {
+			return this.orgPrefs.getIntPref(key);
+		} catch (e) {
+			return defaultVal;
+		}
+	},
+	setIntPref: function(key, val) {
+		this.orgPrefs.setIntPref(key, val);
+	},
+};
 
 //-----------------------------------------------------------------------------
 var strbundle;
@@ -29,13 +91,13 @@ function AFgetPrefString(objId) {
 
 //-----------------------------------------------------------------------------
 function AFreadPref(prefStr, defValue) {
-	var typ = nsPreferences.mPrefService.getPrefType(prefStr);
+	var typ = customPrefs.mPrefService.getPrefType(prefStr);
 	if (typ & 128) {
-		return nsPreferences.getBoolPref(prefStr, defValue);
+		return customPrefs.getBoolPref(prefStr, defValue);
 	} else if (typ & 64) {
-		return nsPreferences.getIntPref(prefStr, defValue);
+		return customPrefs.getIntPref(prefStr, defValue);
 	} else if (typ & 32) {
-		return nsPreferences.copyUnicharPref(prefStr, defValue);
+		return customPrefs.copyUnicharPref(prefStr, defValue);
 	} else {
 		alert(prefStr + ": " + getLocaleString("PrefTypeNotSupported") + ": " + typ);
 	}
@@ -63,11 +125,11 @@ function AFgetObjPref(objId, defValue) {
 
 	var val;
 	if (typ=="bool") {
-		val=nsPreferences.getBoolPref(str, defValue);
+		val=customPrefs.getBoolPref(str, defValue);
 	} else if (typ=="int") {
-		val=nsPreferences.getIntPref(str, defValue);
+		val=customPrefs.getIntPref(str, defValue);
 	} else if (typ=="string") {
-		val=nsPreferences.copyUnicharPref(str, defValue);
+		val=customPrefs.copyUnicharPref(str, defValue);
 	} else {
 		alert(objId + ": " + getLocaleString("PrefTypeNotSupported") + ": " + typ);
 		return;
@@ -88,11 +150,11 @@ function AFwriteObjPref(objId) {
 	eval("val=obj."+atr);
 
 	if (typ=="bool") {
-		nsPreferences.setBoolPref(str, val);
+		customPrefs.setBoolPref(str, val);
 	} else if (typ=="int") {
-		nsPreferences.setIntPref(str, val);
+		customPrefs.setIntPref(str, val);
 	} else if (typ=="string") {
-		nsPreferences.setUnicharPref(str, val);
+		customPrefs.setUnicharPref(str, val);
 	} else {
 		alert(objId + ": " + getLocaleString("PrefTypeNotSupported") + ": " + typ);
 		return;

--- a/install.rdf
+++ b/install.rdf
@@ -16,7 +16,7 @@
 			<r:Description>
 				<id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</id>
 				<minVersion>17.0</minVersion>
-				<maxVersion>31.0.*</maxVersion>
+				<maxVersion>54.*</maxVersion>
 			</r:Description>
 		</targetApplication>
 


### PR DESCRIPTION
It seems nsPreferences has been removed in Thunderbird 54.  Use a
wrapper to emulate it.

Fix the paths in the manifest

Signed-off-by: Ian Wienand <ian@wienand.org>